### PR TITLE
join results in recognize_long_wav_file

### DIFF
--- a/py/client_utils.py
+++ b/py/client_utils.py
@@ -219,7 +219,7 @@ def recognize_long_wav_file(base_url, audio_filepath, recognizer_construct=None,
     send_delete_recognizer(api_url, recognizer_id, requests_obj=requests_obj)
 
     end = time.time()
-    return results, end - start
+    return '\n'.join(results), end - start
 
 # work is the JSON version of 'listfile work'.
 # audio_file is the audio path.


### PR DESCRIPTION
Without this fix I consistently get an `expected string, list found` error in `run_stt.py` when using the `--results_file` flag with `--transmit_method long-file`, because `results` is a list instead of a string.

I don't know python so this is my best stab at a reasonable fix, let me know if there's a better solution.